### PR TITLE
Clarify instructions for console location for bitcoin

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@
     rpcpassword=password3
     ```
 
-1. Start Bitcoin Core (bitcoin-qt), as applicable for your OS. Navigate to the Debug Window.
+1. Start Bitcoin Core (bitcoin-qt), as applicable for your OS. Navigate to the Debug Window (Window » Console).
 
 1. Add the following lines to the liquid.conf file created previously:
 


### PR DESCRIPTION
The debug console changed menu locations in 0.18.0. Clarifying that location in the instructions.